### PR TITLE
Standard ratel configuration contains a bean of type RatelClientFactory

### DIFF
--- a/core/src/main/java/com/payu/ratel/client/standalone/RatelClientFactory.java
+++ b/core/src/main/java/com/payu/ratel/client/standalone/RatelClientFactory.java
@@ -1,0 +1,23 @@
+package com.payu.ratel.client.standalone;
+
+public interface RatelClientFactory {
+
+    /**
+     * Creates a lazily-initialized fully-featured client of the ratel service
+     * with a given contract.
+     * Creation of a proxy does not guarantee that such a service exist.
+     * A lazy initialization means that the client will try to lookup an
+     * address of a service with first call attempt.
+     * The client has all client-side features provided by Ratel, such as
+     * load-balancing, monitoring, fail-over, etc.
+     *
+     * @param <T>
+     *            a type of the service created should contain contract
+     *            interface for the service
+     * @param serviceContractClass
+     *            the desired contract class.
+     * @return a fully-featured service client.
+     */
+    <T> T getServiceProxy(Class<T> serviceContractClass);
+
+}

--- a/core/src/main/java/com/payu/ratel/context/ServiceEvent.java
+++ b/core/src/main/java/com/payu/ratel/context/ServiceEvent.java
@@ -4,7 +4,6 @@ package com.payu.ratel.context;
  * Abstract class representing any event that is risen when communication with
  * service happens on either server or client side. Subclasses represent more
  * specific events.
- *
  */
 public abstract class ServiceEvent {
 
@@ -21,6 +20,8 @@ public abstract class ServiceEvent {
      * The process context that was active when this event was risen.
      * Please note that ProcessContext is mutable, though this class holds a
      * snapshot copy of it taken at the moment when this event was risen.
+     *
+     * @return a process context used upon creation of this event.
      */
     public ProcessContext getProcessContext() {
         return processContext;
@@ -28,6 +29,7 @@ public abstract class ServiceEvent {
 
     /**
      * System time in nano seconds taken when this event was risen.
+     *
      * @return time in nano time
      */
     public long getNanoTime() {

--- a/tests/src/test/java/com/payu/ratel/client/standalone/tests/RatelStandaloneTestConfig.java
+++ b/tests/src/test/java/com/payu/ratel/client/standalone/tests/RatelStandaloneTestConfig.java
@@ -4,6 +4,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import com.payu.ratel.client.RemoteServiceCallListener;
+import com.payu.ratel.client.standalone.RatelClientFactory;
 import com.payu.ratel.client.standalone.RatelStandaloneFactory;
 import com.payu.ratel.tests.service.TestServiceCallListener;
 
@@ -11,7 +12,7 @@ import com.payu.ratel.tests.service.TestServiceCallListener;
 public class RatelStandaloneTestConfig {
 
     @Bean
-    public RatelStandaloneFactory standaloneFactory() {
+    public RatelClientFactory standaloneFactory() {
         return new RatelStandaloneFactory();
     }
 

--- a/tests/src/test/java/com/payu/ratel/client/standalone/tests/StandaloneClientTest.java
+++ b/tests/src/test/java/com/payu/ratel/client/standalone/tests/StandaloneClientTest.java
@@ -38,8 +38,9 @@ import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import com.jayway.awaitility.Awaitility;
+import com.payu.ratel.client.RatelServiceCallPublisher;
 import com.payu.ratel.client.ServiceCallListener;
-import com.payu.ratel.client.standalone.RatelStandaloneFactory;
+import com.payu.ratel.client.standalone.RatelClientFactory;
 import com.payu.ratel.config.ServiceDiscoveryConfig;
 import com.payu.ratel.context.ProcessContext;
 import com.payu.ratel.context.RemoteServiceCallEvent;
@@ -62,7 +63,7 @@ import com.payu.ratel.tests.service.TestServiceConfiguration;
 public class StandaloneClientTest {
 
     @Autowired
-    private RatelStandaloneFactory standaloneFactory;
+    private RatelClientFactory standaloneFactory;
 
     private ConfigurableApplicationContext startedApp;
 
@@ -99,7 +100,7 @@ public class StandaloneClientTest {
         // client side
         TestService testService = standaloneFactory.getServiceProxy(TestService.class);
         ServiceCallListener listener = mock(ServiceCallListener.class);
-        standaloneFactory.addRatelServiceCallListener(listener);
+        ((RatelServiceCallPublisher) standaloneFactory).addRatelServiceCallListener(listener);
         ProcessContext.getInstance().setProcessIdentifier("123");
         // server side
         TestServiceCallListener serverSideListener = startedApp.getBean(TestServiceCallListener.class);

--- a/tests/src/test/java/com/payu/ratel/tests/ServiceDiscoverTest.java
+++ b/tests/src/test/java/com/payu/ratel/tests/ServiceDiscoverTest.java
@@ -27,6 +27,7 @@ import org.springframework.boot.test.SpringApplicationConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import com.payu.ratel.Discover;
+import com.payu.ratel.client.standalone.RatelClientFactory;
 import com.payu.ratel.client.standalone.RatelStandaloneFactory;
 import com.payu.ratel.proxy.NoServiceInstanceFound;
 import com.payu.ratel.tests.service.ProxableService;
@@ -111,7 +112,7 @@ public class ServiceDiscoverTest {
 
         // given
         String ratelAddr = "http://127.0.0.1:" + ratelTestCtx.getServiceDiscoveryPort() + "/server/discovery";
-        RatelStandaloneFactory clientFactory = RatelStandaloneFactory.fromRatelServer(ratelAddr);
+        RatelClientFactory clientFactory = RatelStandaloneFactory.fromRatelServer(ratelAddr);
 
         // when
         TestService testServiceClient = clientFactory.getServiceProxy(TestService.class);

--- a/tests/src/test/java/com/payu/ratel/tests/timeout/TimeoutConfigurationTest.java
+++ b/tests/src/test/java/com/payu/ratel/tests/timeout/TimeoutConfigurationTest.java
@@ -11,6 +11,7 @@ import org.springframework.remoting.RemoteConnectFailureException;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import com.payu.ratel.Discover;
+import com.payu.ratel.client.standalone.RatelClientFactory;
 import com.payu.ratel.client.standalone.RatelStandaloneFactory;
 import com.payu.ratel.tests.RatelTest;
 import com.payu.ratel.tests.RatelTestContext;
@@ -78,7 +79,7 @@ public class TimeoutConfigurationTest {
 
     private TimeoutService getStandaloneTimeoutClient() {
         String ratelAddr = "http://127.0.0.1:" + RatelTestContext.getServiceDiscoveryPort() + "/server/discovery";
-        RatelStandaloneFactory clientFactory = RatelStandaloneFactory.fromRatelServer(ratelAddr);
+        RatelClientFactory clientFactory = RatelStandaloneFactory.fromRatelServer(ratelAddr);
 
         TimeoutService timeoutClient = clientFactory.getServiceProxy(TimeoutService.class);
         return timeoutClient;

--- a/tests/src/test/java/com/payu/ratel/tests/zookeeper/ZookeeperServicePublishingTest.java
+++ b/tests/src/test/java/com/payu/ratel/tests/zookeeper/ZookeeperServicePublishingTest.java
@@ -45,6 +45,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 
 import com.payu.ratel.Discover;
+import com.payu.ratel.client.standalone.RatelClientFactory;
 import com.payu.ratel.client.standalone.RatelStandaloneFactory;
 import com.payu.ratel.config.ServiceDiscoveryConfig;
 import com.payu.ratel.server.DiscoveryServerMain;
@@ -97,7 +98,7 @@ public class ZookeeperServicePublishingTest {
     @Test
     public void shouldCreateStandaloneClientWithZookeeper() {
         //given
-        RatelStandaloneFactory ratelStandaloneFactory = RatelStandaloneFactory.fromZookeeperServer(ZK_HOST);
+        RatelClientFactory ratelStandaloneFactory = RatelStandaloneFactory.fromZookeeperServer(ZK_HOST);
 
         //when
         TestService testedService = ratelStandaloneFactory.getServiceProxy(TestService.class);


### PR DESCRIPTION
that can be injected to the context of a client application.